### PR TITLE
Github action to check whether json files in repo are valid json

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,17 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setting up Python ${{ matrix.python-version }}
+      shell: bash
+      run: |
+        docker build -f Dockerfile -t testbuild .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Setting up Python ${{ matrix.python-version }}
+    - name: 
       shell: bash
       run: |
         docker build -f Dockerfile -t testbuild .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build Docker Image
 
+env:
+  PRERELEASE_BRANCHES: experimental,alpha,beta,rc # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+
 on:
   push:
     branches:
@@ -10,9 +13,30 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      should-publish: ${{ steps.context.outputs.should-publish }}
+      current-version: ${{ steps.context.outputs.current-version }}
+      release-type: ${{ steps.context.outputs.release-type }}
+      cascading-release: ${{ steps.context.outputs.cascading-release }}
+
     steps:
+    - name: Establish context
+      id: context
+      uses: dolittle/establish-context-action@v2
+      with:
+        prerelease-branches: ${{ env.PRERELEASE_BRANCHES }}
+
     - uses: actions/checkout@v3
+
     - name: Build Docker Image
       shell: bash
       run: |
         docker build -f Dockerfile -t testbuild .
+
+    - name: Create GitHub Release
+      uses: dolittle/github-release-action@v1
+      if: ${{ steps.context.outputs.should-publish == 'true' }}
+      with:
+        cascading-release: ${{ steps.context.outputs.cascading-release }}
+        version: ${{ steps.increment-version.outputs.next-version }}
+        body: ${{ steps.context.outputs.pr-body }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
     - name: Build Docker Image
       shell: bash
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ WORKDIR /go/src/app
 COPY main.go .
 
 RUN go mod init
-RUN go get -d -v ./...
-RUN go vet -v
-RUN go test -v
 
 RUN CGO_ENABLED=0 go build -o /go/bin/app
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ This action checks the validity of json files.
 ## Usage
 See [action.yml](action.yml)
 
+Sample workflow:
+```yaml
+steps:
+  - name: Validate json files
+    uses: RaaLabs/validate-json@0.0.2
+    with:
+      directory: "."
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # validate-json
+[![Build Docker Image](https://github.com/RaaLabs/validate-json/actions/workflows/build.yml/badge.svg)](https://github.com/RaaLabs/validate-json/actions/workflows/build.yml)
 
-This action checks the validity of json files.
+This action checks the validity of json files. The action is run using a Docker container and is written in Go.
 
 ## Usage
 See [action.yml](action.yml)
@@ -9,7 +10,7 @@ Sample workflow:
 ```yaml
 steps:
   - name: Validate json files
-    uses: RaaLabs/validate-json@0.0.2
+    uses: RaaLabs/validate-json@0.0.4
     with:
       directory: "."
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,11 @@
 name: 'Validate json files'
 description: 'Check the validity of json files'
 author: 'Raa Labs AS'
+inputs:
+  directory:
+    description: "A directory of files to include in the json validation, defaults to root directory"
+    default: "." # 
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 )
 
 func main() {
-
-	jsonFilepaths := getJsonFilePaths()
+	directory := os.Getenv("INPUT_DIRECTORY")
+	jsonFilepaths := getJsonFilePaths(directory)
 	var failure int
 
 	for _, f := range jsonFilepaths {
@@ -51,10 +51,10 @@ func main() {
 	}
 }
 
-func getJsonFilePaths() []string {
+func getJsonFilePaths(directory string) []string {
 	files := []string{}
 
-	err := filepath.Walk(".",
+	err := filepath.Walk(directory,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ func main() {
 	log.Printf("Using directory: %v\n ", directory)
 	jsonFilepaths := getJsonFilePaths(directory)
 	var failure int
+	var validFiles int
+	var invalidFiles int
 
 	for _, f := range jsonFilepaths {
 		func() {
@@ -39,16 +41,21 @@ func main() {
 			err = json.Unmarshal(js, &data)
 			if err != nil {
 				log.Printf("Json format error: for file %v, failed to unmarshal data: %v\n", f, err)
+				invalidFiles = invalidFiles + 1
 				failure = 1
+			} else {
+				validFiles = validFiles + 1
 			}
 		}()
 	}
 
 	if failure != 0 {
-		log.Printf("Check valid json format: There were json files with invalid format, please correct files above before merging PR")
+		log.Printf("Check valid json format: There were json files with invalid format, please correct files before merging PR")
+		log.Printf("Invalid json files: %v, valid json files: %v", invalidFiles, validFiles)
 		os.Exit(failure)
 	} else {
 		log.Printf("Check valid json format: All json files have valid format")
+		log.Printf("Invalid json files: %v, valid json files: %v", invalidFiles, validFiles)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,8 @@ import (
 )
 
 func main() {
-	directory := os.Getenv("INPUT_DIRECTORY")
+	directory := getEnv("INPUT_DIRECTORY", ".")
+	log.Printf("Using directory: %v\n ", directory)
 	jsonFilepaths := getJsonFilePaths(directory)
 	var failure int
 
@@ -71,4 +72,12 @@ func getJsonFilePaths(directory string) []string {
 	}
 
 	return files
+}
+
+func getEnv(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return defaultValue
+	}
+	return value
 }


### PR DESCRIPTION
Initial GitHub action to check the validity of json files. A sample usage is provided in the readme. Action is written in Go and run as a docker container.

Action can be used like this:
```yaml
steps:
  - name: Validate json files
    uses: RaaLabs/validate-json@0.0.5
    with:
      directory: "."
```

It takes one argument, `directory`, which is the path on which to validate json files. This defaults to the root folder. The action exits with exit code 1 if at least one json file is invalid, otherwise exit code 0. The action prints the number of correctly and incorrectly formatted files. It also prints the error for every incorrectly formatted json file.

This repository needs to be public in order to be published on the GitHub marketplace for actions. GitHub detects that this repo contains a GitHub action and releases created from this repo will be automatically available for use through the GitHub marketplace. The release creation is automated and makes use of the tags `patch`, `minor`, and `major` and the Dolittle GitHub actions.

Thanks to @postmannen for the help on the Go code and the comments on the Dockerfile.