### PR TITLE
Update workflow to use ghcr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build Docker Image
 
 env:
-  PRERELEASE_BRANCHES: experimental,alpha,beta,rc # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+  PRERELEASE_BRANCHES: experimental,alpha,beta,rc
 
 on:
   push:
@@ -28,12 +28,13 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Login to Docker Hub
+    - name: Login to GitHub Container Registry
       if: ${{ steps.context.outputs.should-publish == 'true' }}
       uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Docker Build
       if: ${{ steps.context.outputs.should-publish == 'false' }}
@@ -63,7 +64,7 @@ jobs:
         docker logout
 
     - name: Create GitHub Release
-      uses: dolittle/github-release-action@v1
+      uses: dolittle/github-release-action@v2
       if: ${{ steps.context.outputs.should-publish == 'true' }}
       with:
         cascading-release: ${{ steps.context.outputs.cascading-release }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This action validates json files. The action scans the repository for files with
 
 The action is run using a Docker container and is written in Go.
 
+> **Warning**
+> We are switching from Docker Hub to GitHub container registry to store the images for this action (Docker sunsets free plans for teams). Use version 1.0.0 going forward as the previous versions will stop working once Docker removes the images from Docker hub (pull rate limits apply from 14.April 2023, removal on 14.May 2023)
+
+
 ## Inputs
 - `directory`: (string, optional) The path on which to scan .json files, defaults to `.`, in which case it scans the whole repository.
 
@@ -23,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 
     - name: Validate json files
-      uses: RaaLabs/validate-json@v0.0.7
+      uses: RaaLabs/validate-json@v1.0.0
       with:
         directory: "."
 

--- a/action.yml
+++ b/action.yml
@@ -8,4 +8,4 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://raalabs/validate-json:0.0.7'
+  image: 'docker://ghcr.io/raalabs/validate-json:1.0.0'


### PR DESCRIPTION
Switch out Docker hub with GitHub container registries (Docker is retiring free plans for teams).

> **Warning**
> Use version 1.0.0 going forward as the previous versions will stop working once Docker removes the images from Docker hub (pull rate limits apply from 14.April 2023, removal on 14.May 2023) 